### PR TITLE
Drawable Reference When Applying Color Filter

### DIFF
--- a/MapboxAndroidSDK/src/main/java/com/spatialdev/osm/model/OSMColorConfig.java
+++ b/MapboxAndroidSDK/src/main/java/com/spatialdev/osm/model/OSMColorConfig.java
@@ -99,6 +99,7 @@ public class OSMColorConfig {
     public static Drawable getFocusInDrawable(OSMElement osmElement, Drawable originalDrawable) {
         if(osmElement != null && osmElement.getOsmColorConfig() != null) {
             if(osmElement.getOsmColorConfig().enabled) {
+                originalDrawable = originalDrawable.mutate();
                 ARGB argb = getFocusInARGB(osmElement, osmElement.getOsmColorConfig().defaultArgb);
                 originalDrawable = applyColorFilterToDrawable(originalDrawable, argb);
             }
@@ -109,6 +110,7 @@ public class OSMColorConfig {
     public static Drawable getFocusOutDrawable(OSMElement osmElement, Drawable originalDrawable) {
         if(osmElement != null && osmElement.getOsmColorConfig() != null) {
             if(osmElement.getOsmColorConfig().enabled) {
+                originalDrawable = originalDrawable.mutate();
                 ARGB argb = getFocusOutARGB(osmElement, osmElement.getOsmColorConfig().defaultArgb);
                 originalDrawable = applyColorFilterToDrawable(originalDrawable, argb);
             }

--- a/app/src/main/java/org/redcross/openmapkit/MapActivity.java
+++ b/app/src/main/java/org/redcross/openmapkit/MapActivity.java
@@ -520,6 +520,7 @@ public class MapActivity extends AppCompatActivity implements OSMSelectionListen
      */
     protected void initializeOsmXml() {
         try {
+            forceReloadForColor();
             OSMMapBuilder.buildMapFromExternalStorage(this);
         } catch (Exception e) {
             e.printStackTrace();
@@ -1143,5 +1144,21 @@ public class MapActivity extends AppCompatActivity implements OSMSelectionListen
 
     public AlertDialog getDeleteNodeDialog() {
         return deleteNodeDialog;
+    }
+
+    /**
+     * This method causes OSM data to be reloaded from file so as to prevent in memory map markers
+     * from being used (hence leading to potential stale OSM colors being rendered)
+     */
+    private void forceReloadForColor() {
+        if(ODKCollectHandler.isODKCollectMode()
+                && Constraints.singleton().getFirstColorConfig().isEnabled()) {
+            File[] osmFiles = ExternalStorage.fetchOSMXmlFiles();
+            if(osmFiles != null && osmFiles.length > 0) {
+                for(int i = 0; i < osmFiles.length; i++) {
+                    OSMMapBuilder.removeOSMFileFromModel(osmFiles[i]);
+                }
+            }
+        }
     }
 }

--- a/app/src/main/java/org/redcross/openmapkit/OSMMapBuilder.java
+++ b/app/src/main/java/org/redcross/openmapkit/OSMMapBuilder.java
@@ -138,15 +138,19 @@ public class OSMMapBuilder extends AsyncTask<File, Long, JTSModel> {
             return;
         }
         for (File f : files) {
-            String absPath = f.getAbsolutePath();
-            if (loadedOSMFiles.contains(absPath)) {
-                jtsModel.removeDataSet(absPath);
-                loadedOSMFiles.remove(absPath);
-                persistedOSMFiles.remove(absPath);
-            }
+            removeOSMFileFromModel(f);
         }
         mapActivity.getMapView().invalidate();
         updateSharedPreferences();
+    }
+
+    public static void removeOSMFileFromModel(File file) {
+        String absPath = file.getAbsolutePath();
+        if (loadedOSMFiles.contains(absPath)) {
+            jtsModel.removeDataSet(absPath);
+            loadedOSMFiles.remove(absPath);
+            persistedOSMFiles.remove(absPath);
+        }
     }
     
     public static void addOSMFilesToModel(Set<File> files) {


### PR DESCRIPTION
Make sure color filters are applied to clones of the provided drawable
in OSMColorConfig to prevent the color filter from being applied on all
views using the drawable

Signed-off-by: Jason Rogena jasonrogena@gmail.com
