### PR TITLE
Constraints from ODK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,50 @@
+language: android
+# sudo set to required because of an issue with how TravisCI handles builds in Docker containers https://github.com/travis-ci/travis-ci/issues/3695.
+# Setting sudo to required prevents Travis from testing the project in a Docker container.
+sudo: required
+jdk: oraclejdk8
+env:
+  matrix:
+    - ANDROID_TARGET=android-21 ANDROID_ABI=armeabi-v7a
+  global:
+    # wait up to 10 minutes for adb to connect to emulator
+    - ADB_INSTALL_TIMEOUT=10
+    - MALLOC_ARENA_MAX=2
+
+android:
+  components:
+  - platform-tools
+  - tools
+  - build-tools-23.0.3
+  - android-21
+  - android-23
+  - extra-android-m2repository
+
+  # Emulator for the tests
+  - sys-img-armeabi-v7a-android-21
+
+addons:
+  apt_packages:
+    - pandoc
+  artifacts:
+    paths:
+      - $(git ls-files -o | grep build/outputs | tr "\n" ":")
+
+before_script:
+  - echo no | android create avd --force --name test --target $ANDROID_TARGET --abi $ANDROID_ABI
+  - mksdcard 32M sdcard.img
+  - emulator -avd test -no-skin -no-audio -no-window -sdcard sdcard.img &
+
+script:
+  - android-wait-for-emulator
+  - adb devices
+  - (sleep 120; adb shell input keyevent 82 &) &
+  - ./gradlew connectedAndroidTest -i --stacktrace -x MapboxAndroidSDK:connectedAndroidTest
+
+after_failure:
+  - pandoc app/build/reports/androidTests/connected/index.html -t plain
+
+after_script:
+  # print lint results details
+  - for f in app/build/outputs/lint-results.html; do pandoc $f -t plain; done
+  - for f in data/build/outputs/lint-results.html; do pandoc $f -t plain; done

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,6 +14,7 @@ android {
         targetSdkVersion 21
         versionCode 22
         versionName "1.1"
+        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     buildTypes {
         release {
@@ -48,4 +49,5 @@ dependencies {
     compile "com.android.support:design:${supportLibVersion}"
     compile "com.android.support:cardview-v7:${supportLibVersion}"
     compile "com.android.support:recyclerview-v7:${supportLibVersion}"
+    androidTestCompile 'com.android.support.test:runner:0.5'
 }

--- a/app/src/androidTest/assets/constraints/omk_functional_test.json
+++ b/app/src/androidTest/assets/constraints/omk_functional_test.json
@@ -1,0 +1,5 @@
+{
+  "building": {
+    "required": true
+  }
+}

--- a/app/src/androidTest/java/org/redcross/openmapkit/ApplicationTest.java
+++ b/app/src/androidTest/java/org/redcross/openmapkit/ApplicationTest.java
@@ -1,13 +1,70 @@
 package org.redcross.openmapkit;
 
 import android.app.Application;
+import android.content.Intent;
+import android.os.Environment;
 import android.test.ApplicationTestCase;
+
+import org.apache.commons.io.FileUtils;
+import org.json.JSONObject;
+import org.redcross.openmapkit.odkcollect.ODKCollectHandler;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Iterator;
 
 /**
  * <a href="http://d.android.com/tools/testing/testing_android.html">Testing Fundamentals</a>
  */
 public class ApplicationTest extends ApplicationTestCase<Application> {
+    public static final String TEST_FORM_NAME = "omk_functional_test";
+    public static final String TEST_FORM_INSTANCE_DIR = Environment.getExternalStorageDirectory().getAbsolutePath() + "/odk/instances/omk_functional_test";
     public ApplicationTest() {
         super(Application.class);
+    }
+
+    /**
+     * This method creates an intent similar to the one used to launch OpenMapKit from OpenDataKit
+     *
+     * @return  Intent similar to the one used to launch OpenMapKit from OpenDataKit
+     */
+    public static Intent getLaunchOMKIntent() {
+        File odkInstanceDir = new File(TEST_FORM_INSTANCE_DIR);
+        odkInstanceDir.mkdirs();
+
+        Intent intent = new Intent(Intent.ACTION_SEND);
+        intent.setType("text/plain");
+        intent.putExtra("FORM_FILE_NAME", TEST_FORM_NAME);
+        intent.putExtra("FORM_ID", "-1");
+        intent.putExtra("INSTANCE_ID", "uuid:6004201f-9942-429d-bfa4-e65b683da37b");
+        intent.putExtra("INSTANCE_DIR", TEST_FORM_INSTANCE_DIR);
+        intent.putExtra("OSM_EDIT_FILE_NAME", TEST_FORM_NAME + ".osm");
+        ODKCollectHandler.registerIntent(intent);
+
+        addTagsToIntent(intent);
+
+        return intent;
+    }
+
+    private static void addTagsToIntent(Intent intent) {
+        String formFileName = ODKCollectHandler.getODKCollectData().getFormFileName();
+        try {
+            File formConstraintsFile = ExternalStorage.fetchConstraintsFile(formFileName);
+            String formConstraintsStr = FileUtils.readFileToString(formConstraintsFile);
+            JSONObject formConstraintsJson = new JSONObject(formConstraintsStr);
+            ArrayList<String> tagKeys = new ArrayList<>();
+
+            Iterator<String> keyIterator = formConstraintsJson.keys();
+            while (keyIterator.hasNext()) {
+                String key = keyIterator.next();
+                tagKeys.add(key);
+                intent.putExtra("TAG_LABEL." + key, key);
+                intent.putExtra("TAG_VALUE_LABEL."+key+".yes", "Yes");
+                intent.putExtra("TAG_VALUE_LABEL." + key + ".no", "No");
+            }
+            intent.putExtra("TAG_KEYS", tagKeys);
+        } catch (Exception e) {
+
+        }
     }
 }

--- a/app/src/androidTest/java/org/redcross/openmapkit/ExternalStorageTest.java
+++ b/app/src/androidTest/java/org/redcross/openmapkit/ExternalStorageTest.java
@@ -1,0 +1,122 @@
+package org.redcross.openmapkit;
+
+import android.content.Context;
+import android.content.Intent;
+import android.content.res.AssetManager;
+import android.os.Environment;
+import android.support.test.InstrumentationRegistry;
+import android.text.InputType;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.redcross.openmapkit.odkcollect.ODKCollectHandler;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import static org.junit.Assert.*;
+
+/**
+ * Created by Jason Rogena - jrogena@ona.io on 8/10/16.
+ */
+public class ExternalStorageTest {
+    Intent launchIntent;
+    Context context;
+    @Before
+    public void init() {
+        context = InstrumentationRegistry.getContext();
+        launchIntent = ApplicationTest.getLaunchOMKIntent();
+        createOdkMediaDirectory();
+    }
+
+    /**
+     * Creates the odk media directory on the sdcard and adds any file that will be needed in the
+     * tests
+     */
+    private void createOdkMediaDirectory() {
+        String sdCardPath = Environment.getExternalStorageDirectory().getAbsolutePath();
+        String odkMediaPath = sdCardPath + "/odk/forms/" + ApplicationTest.TEST_FORM_NAME + "-media";
+        File mediaDir = new File(odkMediaPath);
+        mediaDir.mkdirs();
+        AssetManager assetManager = context.getAssets();
+        InputStream is = null;
+        OutputStream os = null;
+        try {
+            String odkConstraintsPath = odkMediaPath + "/" + ExternalStorage.CONSTRAINTS_FILE_NAME_ON_ODK;
+            is = assetManager.open("constraints/" + ApplicationTest.TEST_FORM_NAME + ".json");
+            File odkConstraintsFile = new File(odkConstraintsPath);
+            os = new FileOutputStream(odkConstraintsFile);
+            byte[] buffer = new byte[1024];
+            int read;
+            while((read = is.read(buffer)) != -1){
+                os.write(buffer, 0, read);
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        } finally {
+            try {
+                if(is != null) is.close();
+                if(os != null) os.close();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    /**
+     * Tests whether constraints files are copied over from ODK's media directory for the form to
+     * OMK's constraints directory
+     */
+    @Test
+    public void testCopyFormConstraintsFromOdk() {
+        String sdCardPath = Environment.getExternalStorageDirectory().getAbsolutePath();
+
+        //make sure the constraints directory exists
+        String omkConstraintsDirPath = sdCardPath + "/" + ExternalStorage.APP_DIR
+                + "/" + ExternalStorage.CONSTRAINTS_DIR;
+        File omkConstraintsDir = new File(omkConstraintsDirPath);
+        omkConstraintsDir.mkdirs();
+
+        //make sure the test form's constraint file is not in the constraints directory
+        String omkConstraintsFilePath = omkConstraintsDirPath
+                + "/" + ApplicationTest.TEST_FORM_NAME + ".json";
+        File omkConstraintsFile = new File(omkConstraintsFilePath);
+        if(omkConstraintsFile.exists()) {
+            omkConstraintsFile.delete();
+        }
+
+        //try copying over the file from ODK
+        ExternalStorage.copyFormConstraintsFromOdk(ApplicationTest.TEST_FORM_NAME);
+
+        //check if file was copied
+        File file = new File(omkConstraintsFilePath);
+        assertTrue(file.exists());
+
+        //check if contents of file are what is expected
+        AssetManager assetManager = context.getAssets();
+        InputStream is = null;
+        try {
+            is = assetManager.open("constraints/" + ApplicationTest.TEST_FORM_NAME + ".json");
+            String assetString = IOUtils.toString(is);
+            String formFileName = ODKCollectHandler.getODKCollectData().getFormFileName();
+            File formConstraintsFile = ExternalStorage.fetchConstraintsFile(formFileName);
+            String formConstraintsStr = FileUtils.readFileToString(formConstraintsFile);
+
+            assertEquals(assetString, formConstraintsStr);
+        } catch (IOException e) {
+            e.printStackTrace();
+            assertTrue(e.getMessage(), false);
+        } finally {
+            try {
+                if(is != null) is.close();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/redcross/openmapkit/Constraints.java
+++ b/app/src/main/java/org/redcross/openmapkit/Constraints.java
@@ -224,6 +224,7 @@ public class Constraints {
         if (!ODKCollectHandler.isODKCollectMode()) return;
 
         String formFileName = ODKCollectHandler.getODKCollectData().getFormFileName();
+        ExternalStorage.copyFormConstraintsFromOdk(formFileName);
         try {
             File formConstraintsFile = ExternalStorage.fetchConstraintsFile(formFileName);
             String formConstraintsStr = FileUtils.readFileToString(formConstraintsFile);

--- a/app/src/main/java/org/redcross/openmapkit/ExternalStorage.java
+++ b/app/src/main/java/org/redcross/openmapkit/ExternalStorage.java
@@ -47,7 +47,7 @@ public class ExternalStorage {
     /**
      * The name of the form specific constraints file if it were to be delivered as an ODK media file
      */
-    private static final String CONSTRAINTS_FILE_NAME_ON_ODK = "omk-constraints.json";
+    public static final String CONSTRAINTS_FILE_NAME_ON_ODK = "omk-constraints.json";
 
     /**
      * Creating the application directory structure.

--- a/app/src/main/java/org/redcross/openmapkit/ExternalStorage.java
+++ b/app/src/main/java/org/redcross/openmapkit/ExternalStorage.java
@@ -5,6 +5,8 @@ import android.content.res.AssetManager;
 import android.os.Environment;
 import android.util.Log;
 
+import com.google.common.io.Files;
+
 import org.apache.commons.io.FilenameUtils;
 import org.json.JSONObject;
 
@@ -41,6 +43,11 @@ public class ExternalStorage {
     public static final String DEPLOYMENTS_DIR = "deployments";
     public static final String CONSTRAINTS_DIR = "constraints";
     public static final String DEFAULT_CONSTRAINT = "default.json";
+
+    /**
+     * The name of the form specific constraints file if it were to be delivered as an ODK media file
+     */
+    private static final String CONSTRAINTS_FILE_NAME_ON_ODK = "omk-constraints.json";
 
     /**
      * Creating the application directory structure.
@@ -367,8 +374,36 @@ public class ExternalStorage {
         return new File(constraintsDir, formName + ".json");
     }
 
+    /**
+     * This method attempts to fetch the form's constraints file from ODK's media directory for the
+     * form. If the constraints file is found on ODK's media directory for the form, its contents
+     * will overwrite whatever is in OMK's constraints file for the form
+     *
+     * @param formFileName  The name of the ODK form
+     * @return TRUE if there was a successful copy
+     */
+    public static boolean copyFormConstraintsFromOdk(String formFileName) {
+        String sdCardPath = Environment.getExternalStorageDirectory().getAbsolutePath();
+        if(formFileName != null) {
+            String mediaDirPath = sdCardPath + "/odk/forms/" + formFileName + "-media";
+            File mediaDirectory = new File(mediaDirPath);
+            if(mediaDirectory.exists() && mediaDirectory.isDirectory()) {
+                String constraintsFilePath = mediaDirPath + "/" + CONSTRAINTS_FILE_NAME_ON_ODK;
+                File odkConstraintsFile = new File(constraintsFilePath);
+                if(odkConstraintsFile.exists() && !odkConstraintsFile.isDirectory()) {
+                    File omkConstraintsFile = fetchConstraintsFile(formFileName);
+                    try {
+                        Files.copy(odkConstraintsFile, omkConstraintsFile);
+                        return true;
+                    } catch (IOException e) {
+                        e.printStackTrace();
+                    }
+                }
+            }
+        }
 
-
+        return false;
+    }
 
     /**
      * From


### PR DESCRIPTION
Adds functionality for fetching a forms OMK constraints file from its ODK media directory on the sdcard.

This pull request has been made on this repository for QA purpose only (shouldn't be merged). After QA, a pull request will be made onto [upstream](https://github.com/americanredcross/openmapkitandroid) against [this issue](https://github.com/AmericanRedCross/OpenMapKitAndroid/issues/156)
