### PR TITLE
Required Tag Forward Swipe

### DIFF
--- a/app/src/main/java/org/redcross/openmapkit/tagswipe/SelectOneTagValueFragment.java
+++ b/app/src/main/java/org/redcross/openmapkit/tagswipe/SelectOneTagValueFragment.java
@@ -214,7 +214,7 @@ public class SelectOneTagValueFragment extends Fragment {
         
         @Override
         public void onClick(View v) {
-            radioButton.toggle();
+            radioButton.performClick();
         }
     }
     

--- a/app/src/main/java/org/redcross/openmapkit/tagswipe/TagEdit.java
+++ b/app/src/main/java/org/redcross/openmapkit/tagswipe/TagEdit.java
@@ -318,11 +318,14 @@ public class TagEdit {
 
         return true;
     }
+
+    private static Set<String> getMissingRequiredTags() {
+        updateTagsInOSMElement();
+        return Constraints.singleton().requiredTagsNotMet(osmElement);
+    }
     
     public static boolean saveToODKCollect(String osmUserName) {
-        updateTagsInOSMElement();
-
-        Set<String> missingTags = Constraints.singleton().requiredTagsNotMet(osmElement);
+        Set<String> missingTags = getMissingRequiredTags();
         tagSwipeActivity.setOsmFilePath(null);
         if (missingTags.size() > 0) {
             tagSwipeActivity.notifyMissingTags(missingTags);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -100,5 +100,6 @@
     <string name="an_error_occurred_retag">An error occurred. Please re-tag the %1$s</string>
     <string name="title_activity_query">QueryActivity</string>
     <string name="querying_please_wait">Querying OMK, please wait...</string>
+    <string name="fill_tag">Make sure you fill this tag before proceeding to the next screen</string>
 
 </resources>


### PR DESCRIPTION
Prevents the user from swiping forward if they haven't filled the current
tag if it's required.

Fixes issue #81

Signed-off-by: Jason Rogena <jasonrogena@gmail.com>